### PR TITLE
Improve navigation

### DIFF
--- a/we4us/src/App.tsx
+++ b/we4us/src/App.tsx
@@ -16,8 +16,7 @@ import CommunityPage from './pages/CommunityPage';
 import Modal from "react-modal";
 import AppContextProvider from './AppContextProvider';
 import SearchPage from './pages/SearchPage';
-import BackButton from './components/BackButton';
-import HomeButton from './components/HomeButton';
+import { BackButton, HomeButton } from './components/NavButtons';
 
 Modal.setAppElement('#root');
 

--- a/we4us/src/components/BackButton.tsx
+++ b/we4us/src/components/BackButton.tsx
@@ -1,7 +1,0 @@
-import { useNavigate } from "react-router-dom";
-import { ArrowBigLeft } from "lucide-react";
-
-export default function BackButton() {
-    const navigate = useNavigate();
-    return <button onClick={() => navigate(-1)}><ArrowBigLeft/></button>;
-}

--- a/we4us/src/components/HomeButton.tsx
+++ b/we4us/src/components/HomeButton.tsx
@@ -1,7 +1,0 @@
-import { useNavigate } from "react-router-dom";
-import { House } from "lucide-react";
-
-export default function HomeButton() {
-    const navigate = useNavigate();
-    return <button onClick={() => navigate("/")}><House/></button>;
-}

--- a/we4us/src/components/NavButtons.tsx
+++ b/we4us/src/components/NavButtons.tsx
@@ -1,0 +1,16 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { ArrowBigLeft, House } from "lucide-react";
+
+export function BackButton() {
+    const location = useLocation();
+    const navigate = useNavigate();
+    return <button onClick={() => {
+        if (location.key === "default") return;
+        else navigate(-1)
+    }}><ArrowBigLeft /></button>;
+}
+
+export function HomeButton() {
+    const navigate = useNavigate();
+    return <button onClick={() => navigate("/")}><House /></button>;
+}


### PR DESCRIPTION
Moved navigation logic out of Who's who, profile page and into the App. Allows navigation to work globally.

Changes:
- Create button for 'back', 'go to home' actions
- route 'home' to "/". Which is currently the route for 'Landing Page'
- insert button into the common page layout.

Screenshots:
![Screenshot 2025-03-07 120102](https://github.com/user-attachments/assets/3f15df09-bdb9-4718-ae2f-8a6a6da304f3)
![Screenshot 2025-03-07 120112](https://github.com/user-attachments/assets/beed3ce5-fdd7-4daa-9b03-7cc7a3fc131e)
![Screenshot 2025-03-07 120127](https://github.com/user-attachments/assets/23ceac5b-44ee-49cb-b29c-8c3cda8e2e68)
