### PR TITLE
Enable 'find all communities' usecase

### DIFF
--- a/we4us/src/components/CommunityList.tsx
+++ b/we4us/src/components/CommunityList.tsx
@@ -8,7 +8,9 @@ let styles = {
         padding: 0
     },
     listItem: {
-
+        border: "1px solid #ccc",
+        borderRadius: "8px",
+        margin: "1%"
     }
 }
 

--- a/we4us/src/components/LemmySearchBar.tsx
+++ b/we4us/src/components/LemmySearchBar.tsx
@@ -19,7 +19,7 @@ export default function LemmySearchBar({ handleSearch }:
     }
     return (
         <form onSubmit={passParamsOut}>
-            <input name="query" placeholder="Search content" required />
+            <input name="query" placeholder="Search query" />
             <label htmlFor="type">Type</label>
             <select name="type">
                 <option value="All">All</option>


### PR DESCRIPTION
Initial task was to create a list of communities on reaching out. This would be a headache managing in terms of UI as more and more communities are added.

Changes:
- updated 'Search' to enable query-less searches.
- adjust CSS so the results look better defined

Screenshots:
CommunityPage
![Screenshot 2025-03-07 124541](https://github.com/user-attachments/assets/53f310f7-6b87-4c2a-886f-c0f58e204d09)
CommunityList
![Screenshot 2025-03-07 124619](https://github.com/user-attachments/assets/63e7b65f-ccd3-4e9d-91f1-df085afed45c)