### PR TITLE
Preserve profile order after update by sorting by username

### DIFF
--- a/postgres-wrapper/lib/we4us/profiles.ex
+++ b/postgres-wrapper/lib/we4us/profiles.ex
@@ -7,7 +7,7 @@ defmodule We4us.Profiles do
 
   #Fetch all profiles
   def list_profiles do
-    Repo.all(Profile)
+    Repo.all(from p in Profile, order_by: [asc: p.username])
   end
 
   #Fetch a single profile by username


### PR DESCRIPTION
Changes:

- Fix the order in which profiles are listed by sorting acc to username.


![image](https://github.com/user-attachments/assets/ae6379ea-940f-480a-ae8b-7d104d232669)
After editing the profile of @c4User2, the user's profile card is not reordered.