### PR TITLE
Throw error if profile not found. On error, show the redirect page.

### DIFF
--- a/postgres-wrapper/lib/we4us_web/channels/message_channel.ex
+++ b/postgres-wrapper/lib/we4us_web/channels/message_channel.ex
@@ -1,57 +1,53 @@
 defmodule We4usWeb.MessageChannel do
   use We4usWeb, :channel
+  alias We4us.Profiles
+
   require Logger
-    @impl true
-def join("message:" <> recipientname, payload, socket) do
-  if authorized?(payload) do
-    sender_id = payload["username"]
-    socket = assign(socket, :username, sender_id)
+  @impl true
+  def join("message:" <> channelName, payload, socket) do
+    if authorized?(payload) do
+      sender_id = payload["username"]
 
-    # Log the join attempt for debugging
-    Logger.debug("User #{sender_id} joining channel for #{recipientname}")
+      if String.contains?(channelName, "#") do
+        [user1, user2] = String.split(channelName, "#")
+        other_user = if sender_id == user1, do: user2, else: user1
 
-    # Check if this is a combined channel ID (contains underscore)
-    if String.contains?(recipientname, "#") do
-      # Split the combined ID to get both users
-      [user1, user2] = String.split(recipientname, "#")
+        case Profiles.get_profile(other_user) do
+          nil ->
+            {:error, %{reason: "Profile does not exist", status: 404}}
 
-      # Determine who the other user is
-      other_user = if sender_id == user1, do: user2, else: user1
+          _profile ->
+            socket = assign(socket, :username, sender_id)
 
-      # Get conversation
-      messages = case We4us.Messages.get_conversation(sender_id, other_user) do
-        {:ok, msgs} ->
-          Logger.debug("Found #{length(msgs)} messages for combined channel")
-          msgs
-        {:error, err} ->
-          Logger.error("Error fetching messages for combined channel: #{inspect(err)}")
-          []
+            # Log the join attempt for debugging
+            Logger.debug("User #{sender_id} joining channel for #{channelName}")
+
+            # Get conversation
+            messages =
+              case We4us.Messages.get_conversation(sender_id, other_user) do
+                {:ok, msgs} ->
+                  Logger.debug("Found #{length(msgs)} messages for combined channel")
+                  msgs
+
+                {:error, err} ->
+                  Logger.error("Error fetching messages for combined channel: #{inspect(err)}")
+                  []
+              end
+
+            {:ok, %{messages: format_messages(messages)}, socket}
+        end
+      else
+        {:error, %{reason: "Invalid channel name for messages", status: 422}}
       end
-
-      {:ok, %{messages: format_messages(messages)}, socket}
     else
-      # Backward compatibility for old-style channels
-      messages = case We4us.Messages.get_conversation(sender_id, recipientname) do
-        {:ok, msgs} ->
-          Logger.debug("Found #{length(msgs)} messages")
-          msgs
-        {:error, err} ->
-          Logger.error("Error fetching messages: #{inspect(err)}")
-          []
-      end
-
-      {:ok, %{messages: format_messages(messages)}, socket}
+      {:error, %{reason: "unauthorized", status: 401}}
     end
-  else
-    {:error, %{reason: "unauthorized"}}
   end
-end
 
   @impl true
   def handle_in("send_message", %{"to" => to_user, "body" => body}, socket) do
     from_user = socket.assigns.username
     users = [from_user, to_user] |> Enum.sort()
-
 
     message_params = %{
       "from_user" => from_user,
@@ -80,6 +76,7 @@ end
         {:reply, {:error, %{reason: "Failed to save message"}}, socket}
     end
   end
+
   defp format_messages(messages) do
     Enum.map(messages, fn msg ->
       %{
@@ -91,8 +88,6 @@ end
       }
     end)
   end
-
-
 
   # Add authorization logic here as required.
   defp authorized?(_payload) do


### PR DESCRIPTION
Ensure infinite channels are not created, which could cause performance issues and waste memory

The phoenix console should show that the channel is not created.

Screenshot: 
![image](https://github.com/user-attachments/assets/5347b769-07e0-4600-b7a3-655f461cd51a)
